### PR TITLE
Skip data files that fail to load in date-filter path (follow-up to #182)

### DIFF
--- a/lib/relaton/iso/bibliography.rb
+++ b/lib/relaton/iso/bibliography.rb
@@ -242,6 +242,10 @@ module Relaton
       # @return [Relaton::Iso::ItemData, nil]
       def fetch_and_check_date(hit, pubid, opts)
         ret = hit.item
+        # A data file that fails to load (e.g. the index references a file that
+        # 404s) yields an item with no docidentifier; skip it rather than crash.
+        return unless ret&.docidentifier&.first
+
         if publication_date_in_range?(ret, opts)
           Util.info "Found: `#{ret.docidentifier.first.content}`", key: pubid.to_s
           ret

--- a/spec/relaton/iso/bibliography_spec.rb
+++ b/spec/relaton/iso/bibliography_spec.rb
@@ -546,6 +546,19 @@ RSpec.describe Relaton::Iso::Bibliography do
       expect(result.docidentifier.first.content).to eq "ISO 32000-2:2020/DAM 1"
     end
 
+    # If the index references a data file that 404s, the fetched item has no
+    # docidentifier; under a date filter it must degrade to "not found" rather
+    # than raise (regression for the crash exposed by the fix above).
+    it "returns nil instead of raising when the data file fails to load" do
+      empty_item = instance_double(Relaton::Iso::ItemData, docidentifier: [])
+      allow_any_instance_of(Relaton::Iso::Hit).to receive(:item).and_return(empty_item)
+      expect do
+        result = described_class.get("ISO 32000-2:2020/DAM 1", nil,
+                                     publication_date_before: Date.new(2026, 1, 1))
+        expect(result).to be_nil
+      end.not_to raise_error
+    end
+
     it "filters out corrected date after the cut-off", vcr: "iso_iec_2382_2015" do
       result = described_class.get("ISO/IEC 2382", "2015",
                                    publication_date_before: Date.new(2020, 1, 1))


### PR DESCRIPTION
Follow-up to #182. That PR was merged with only the year-fallback commit; this robustness guard — needed alongside it — landed on the branch after the merge and so wasn't included.

## Why it's needed

The year fix in #182 lets amendments reach `fetch_and_check_date`. If the index references a data file that 404s, `hit.item` returns an item with no docidentifier and the method crashes on `ret.docidentifier.first.content`. This is not hypothetical: as of 2026-06-12 the relaton-data-iso `v2` data files for `ISO 32000-2:2020/DAM 1` (`data/iso-32000-2-2020-dam-1.yaml`) return 404 while index-v1 still lists them, so a live build hit exactly this crash.

## Fix

Guard `fetch_and_check_date` so a candidate whose data failed to load is skipped and the lookup degrades to "not found" instead of raising:

```ruby
ret = hit.item
return unless ret&.docidentifier&.first
```

Verified end-to-end against Peter's mn-playground build: with the guard the real Metanorma compile logs a clean `Not found` (exit 0) instead of crashing.

## Tests

- `"returns nil instead of raising when the data file fails to load"` locks the guard.
- Full `bibliography_spec.rb` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)