### PR TITLE
Add `supplement` to the ISO doctype TYPES enum (#185)

### DIFF
--- a/lib/relaton/iso/data_parser.rb
+++ b/lib/relaton/iso/data_parser.rb
@@ -36,6 +36,7 @@ module Relaton
         "Amd" => "amendment",
         "Cor" => "technical-corrigendum",
         "Add" => "addendum",
+        "Suppl" => "supplement",
       }.freeze
 
       DOC_URL = "https://www.iso.org/standard/%d.html"

--- a/lib/relaton/iso/model/doctype.rb
+++ b/lib/relaton/iso/model/doctype.rb
@@ -4,7 +4,7 @@ module Relaton
       TYPES = %w[
         international-standard technical-specification technical-report publicly-available-specification
         international-workshop-agreement guide recommendation amendment technical-corrigendum directive
-        committee-document addendum
+        committee-document addendum supplement
       ].freeze
 
       attribute :content, :string, values: TYPES

--- a/spec/relaton/iso/data_parser_spec.rb
+++ b/spec/relaton/iso/data_parser_spec.rb
@@ -166,6 +166,8 @@ describe Relaton::Iso::DataParser do
     expect(build({ "deliverableType" => "TR" }).ext.doctype.content).to eq "technical-report"
     expect(build({ "supplementType" => "Amd" }).ext.doctype.content).to eq "amendment"
     expect(build({ "supplementType" => "Cor" }).ext.doctype.content).to eq "technical-corrigendum"
+    expect(build({ "supplementType" => "Add" }).ext.doctype.content).to eq "addendum"
+    expect(build({ "supplementType" => "Suppl" }).ext.doctype.content).to eq "supplement"
   end
 
   it "splits the rss URL path by zero-padded id (4- and 5-digit ids)" do


### PR DESCRIPTION
## Summary

Fixes #185. [metanorma-iso#1562](https://github.com/metanorma/metanorma-iso/issues/1562) introduced the **Supplement** ISO deliverable (PubID `ISO …/Suppl N:YYYY`), modelled on Addendum. relaton-iso's doctype model did not recognise `supplement`, so parsing or citing a Supplement bibliographic item would fail validation against `Doctype::TYPES`.

## Changes

- **`lib/relaton/iso/model/doctype.rb`** — add `supplement` to the `TYPES` allow-list.
- **`lib/relaton/iso/data_parser.rb`** — map the Open Data `supplementType` code `Suppl` to `supplement` in `SUPPLEMENT_DOCTYPES`, matching pubid-iso's canonical abbreviation (`Pubid::Iso::Identifier::Supplement.type` → `values: %w[Supplement Suppl SUP]`).
- **`spec/relaton/iso/data_parser_spec.rb`** — assert the `Suppl => supplement` mapping, plus the previously-untested `Add => addendum`.

## Note

The `Suppl` feed-code mapping is an educated inference — there's no real Open Data record with a supplement on hand to confirm the exact `supplementType` string. `Suppl` is consistent with pubid-iso and with how `Amd`/`Cor`/`Add` are keyed. If the feed turns out to emit `Sup`/`SUP`, only that one map key needs adjusting. The doctype-enum addition is correct regardless.

## Testing

`bundle exec rspec spec/relaton/iso/data_parser_spec.rb` — 13 examples, 0 failures.

Refs metanorma/metanorma-iso#1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)