### PR TITLE
Add `extract` deliverable doctype (#188)

### DIFF
--- a/lib/relaton/iso/data_parser.rb
+++ b/lib/relaton/iso/data_parser.rb
@@ -37,6 +37,7 @@ module Relaton
         "Cor" => "technical-corrigendum",
         "Add" => "addendum",
         "Suppl" => "supplement",
+        "Ext" => "extract",
       }.freeze
 
       DOC_URL = "https://www.iso.org/standard/%d.html"

--- a/lib/relaton/iso/model/doctype.rb
+++ b/lib/relaton/iso/model/doctype.rb
@@ -4,7 +4,7 @@ module Relaton
       TYPES = %w[
         international-standard technical-specification technical-report publicly-available-specification
         international-workshop-agreement guide recommendation amendment technical-corrigendum directive
-        committee-document addendum supplement
+        committee-document addendum supplement extract
       ].freeze
 
       attribute :content, :string, values: TYPES

--- a/relaton-iso.gemspec
+++ b/relaton-iso.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 3.2.0")
 
   spec.add_dependency "isoics", "~> 0.1.6"
-  spec.add_dependency "pubid-iso", "~> 1.15.8"
+  spec.add_dependency "pubid-iso", "~> 1.15.20"
   spec.add_dependency "relaton-bib", "~> 2.1.0"
   spec.add_dependency "relaton-core", "~> 0.0.12"
   spec.add_dependency "relaton-index", "~> 0.2.12"

--- a/spec/relaton/iso/data_parser_spec.rb
+++ b/spec/relaton/iso/data_parser_spec.rb
@@ -168,6 +168,7 @@ describe Relaton::Iso::DataParser do
     expect(build({ "supplementType" => "Cor" }).ext.doctype.content).to eq "technical-corrigendum"
     expect(build({ "supplementType" => "Add" }).ext.doctype.content).to eq "addendum"
     expect(build({ "supplementType" => "Suppl" }).ext.doctype.content).to eq "supplement"
+    expect(build({ "supplementType" => "Ext" }).ext.doctype.content).to eq "extract"
   end
 
   it "splits the rss URL path by zero-padded id (4- and 5-digit ids)" do


### PR DESCRIPTION
## Summary

Fixes #188. Following #186 (which added `supplement`), ISO's **Extract** deliverable (PubID `ISO …/Ext N:YYYY`) needs the same treatment. metanorma-iso now emits `extract` as a doctype (metanorma/metanorma-iso#1562, PR metanorma/metanorma-iso#1566) and pubid-iso already renders it (`Pubid::Iso::Identifier::Extract`). Without this, parsing or citing an ISO extract fails validation against `Doctype::TYPES`.

## Changes

- **`lib/relaton/iso/model/doctype.rb`** — add `extract` to the `TYPES` allow-list.
- **`lib/relaton/iso/data_parser.rb`** — map the Open Data `supplementType` code `Ext` to `extract` in `SUPPLEMENT_DOCTYPES`. The `doctype` method already resolves via this map, so no other change is needed.
- **`spec/relaton/iso/data_parser_spec.rb`** — assert the `Ext => extract` mapping.

## Note

Like the `Suppl` mapping in #186, the `Ext` feed code is an educated inference consistent with pubid-iso and with how `Amd`/`Cor`/`Add`/`Suppl` are keyed. If the feed turns out to emit a different string (e.g. `EXT`), only that one map key needs adjusting; the doctype-enum addition is correct regardless.

## Testing

`bundle exec rspec spec/relaton/iso/data_parser_spec.rb` — 13 examples, 0 failures.

Refs metanorma/metanorma-iso#1562

🤖 Generated with [Claude Code](https://claude.com/claude-code)